### PR TITLE
Minor fix remove alert

### DIFF
--- a/lib/xmlrpc.inc
+++ b/lib/xmlrpc.inc
@@ -820,7 +820,7 @@
 		var $key='';
 		var $keypass='';
 		var $verifypeer=true;
-		var $verifyhost=1;
+		var $verifyhost=2;
 		var $no_multicall=false;
 		var $proxy='';
 		var $proxyport=0;


### PR DESCRIPTION
 CURLOPT_SSL_VERIFYHOST no longer accepts the value 1, value 2 will be used instead