### PR TITLE
Less specific date type detection

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -63,11 +63,11 @@ class Encoder
                         $out = strtotime($out);
                     }
                     if (is_int($out)) {
-                        $result = new \Datetime();
+                        $result = new \DateTime();
                         $result->setTimestamp($out);
 
                         return $result;
-                    } elseif (is_a($out, 'Datetime')) {
+                    } elseif (is_a($out, 'DateTimeInterface')) {
                         return $out;
                     }
                 }
@@ -179,7 +179,7 @@ class Encoder
             case 'object':
                 if (is_a($phpVal, 'PhpXmlRpc\Value')) {
                     $xmlrpcVal = $phpVal;
-                } elseif (is_a($phpVal, 'DateTime')) {
+                } elseif (is_a($phpVal, 'DateTimeInterface')) {
                     $xmlrpcVal = new Value($phpVal->format('Ymd\TH:i:s'), Value::$xmlrpcStruct);
                 } else {
                     $arr = array();


### PR DESCRIPTION
The `Encoder::encode` method detects a date by checking whether it is a `DateTime` instance. The `DateTime` class implements the `DateTimeInterface` interface which also supports the `format` method.

So I've changed `DateTime` to `DateTimeInterface` to make a `DateTimeImmutable` object and other implementations also be detected as a date.