### PR TITLE
Limit phpunit version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ before_script:
   - if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then ./tests/ci/travis/setup_hhvm.sh; ./tests/ci/travis/setup_apache_hhvm.sh; fi
   - ./tests/ci/travis/setup_privoxy.sh
 
+  # output what version of phpunit we got going
+  - vendor/bin/phpunit --version
+
 script:
   # Travis currently compiles PHP with an oldish cURL/GnuTLS combination;
   # to make the tests pass when Apache has a bogus SSL cert whe need the full set of options below

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-xml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.0.0",
+        "phpunit/phpunit": "<4.8.35 || >= 5.0, <5.7.20",
         "phpunit/phpunit-selenium": "*",
         "codeclimate/php-test-reporter": "dev-master",
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ext-xml": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "<4.8.35 || >= 5.0, <5.7.20",
+        "phpunit/phpunit": ">=4.0.0, <6.0.0",
         "phpunit/phpunit-selenium": "*",
         "codeclimate/php-test-reporter": "dev-master",
         "ext-curl": "*",


### PR DESCRIPTION
Currently Travis is [unable](https://travis-ci.org/gggeek/phpxmlrpc/jobs/242744576) to test the application because it installs phpunit 6. Phpunit 6 has a different namespace and classname declaration which isn't compatible with the phpxmlrpc library. This PR limits the version of phpunit to 5.7.20 and outputs what version is used when running through Travis.