### PR TITLE
fix HTTP/1.1 417 Expectation Failed Bug

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -873,6 +873,9 @@ class Client
             $headers[] = $encodingHdr;
         }
 
+        // Fixes the HTTP/1.1 417 Expectation Failed Bug
+        $headers[] = 'Expect:';
+
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
         // timeout is borked
         if ($timeout) {


### PR DESCRIPTION
this commonly happens when lighttpd is the backend server.

some links (in no particular order):
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/417
- https://chrismckee.co.uk/curl-http-417-expectation-failed/
- http://digital.ni.com/public.nsf/allkb/0D529B234D2A3A14862580CD003998D4