### PR TITLE
client: use slash as name/version separator

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -187,7 +187,7 @@ class Client
         }*/
 
         // initialize user_agent string
-        $this->user_agent = PhpXmlRpc::$xmlrpcName . ' ' . PhpXmlRpc::$xmlrpcVersion;
+        $this->user_agent = PhpXmlRpc::$xmlrpcName . '/' . PhpXmlRpc::$xmlrpcVersion;
     }
 
     /**


### PR DESCRIPTION
this avoids weird ambiguity "XML-RPC for PHP 4.2.1" sounds like it's for PHP 4.2.1

personally i would change whole agent to be project name "PHPXMLRPC/4.2.1" or "phpxmlrpc/4.2.1", but that might break some scenarios when useragent is matched on remote side.