### PR TITLE
Update for php 7.2 compatibility issue

### DIFF
--- a/lib/xmlrpc.inc
+++ b/lib/xmlrpc.inc
@@ -2684,7 +2684,7 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 			xml_set_default_handler($parser, 'xmlrpc_dh');
 
 			// first error check: xml not well formed
-			if(!xml_parse($parser, $data, count($data)))
+			if(!xml_parse($parser, $data, 1))
 			{
 				// thanks to Peter Kocks <peter.kocks@baygate.com>
 				if((xml_get_current_line_number($parser)) == 1)


### PR DESCRIPTION
Getting rid of "Warning: count(): Parameter must be an array or an object that implements Countable" that Php 7.2 throws