### PR TITLE
Made it possible to wrap namespaced classes with a different namespace

### DIFF
--- a/demo/server/methodProviders/wrapper.php
+++ b/demo/server/methodProviders/wrapper.php
@@ -138,6 +138,8 @@ $c = new xmlrpcServerMethodsContainer();
 
 $moreSignatures = $wrapper->wrapPhpClass($c, array('prefix' => 'tests.', 'method_type' => 'all'));
 
+$namespaceSignatures = $wrapper->wrapPhpClass($c, array('namespace' => 'namespacetest', 'method_type' => 'all'));
+
 $returnObj_sig =  $wrapper->wrapPhpFunction(array($c, 'returnObject'), '', array('encode_php_objs' => true));
 
 return array_merge(
@@ -154,5 +156,6 @@ return array_merge(
         'tests.getStateName.11' => $findstate11_sig,
         'tests.returnPhpObject' => $returnObj_sig,
     ),
+    $namespaceSignatures,
     $moreSignatures
 );

--- a/src/Wrapper.php
+++ b/src/Wrapper.php
@@ -622,8 +622,8 @@ class Wrapper
      * @param array $extraOptions see the docs for wrapPhpMethod for basic options, plus
      *                            - string method_type    'static', 'nonstatic', 'all' and 'auto' (default); the latter will switch between static and non-static depending on whether $className is a class name or object instance
      *                            - string method_filter  a regexp used to filter methods to wrap based on their names
-     *                            - string prefix         used for the names of the xmlrpc methods created
-     *
+     *                            - string prefix         used for the names of the xmlrpc methods created.
+     *                            - string namespace      use when classes with actual namespaces should only have one namespace. e.g. \Some\Namespace\Api is needed as my.Api set this to "my". Works in conjunction with prefix!
      * @return array|false false on failure
      */
     public function wrapPhpClass($className, $extraOptions = array())
@@ -631,6 +631,7 @@ class Wrapper
         $methodFilter = isset($extraOptions['method_filter']) ? $extraOptions['method_filter'] : '';
         $methodType = isset($extraOptions['method_type']) ? $extraOptions['method_type'] : 'auto';
         $prefix = isset($extraOptions['prefix']) ? $extraOptions['prefix'] : '';
+        $namespace = isset($extraOptions['namespace']) ? $extraOptions['namespace'] : '';
 
         $results = array();
         $mList = get_class_methods($className);
@@ -643,10 +644,14 @@ class Wrapper
                     ) {
                         $methodWrap = $this->wrapPhpFunction(array($className, $mName), '', $extraOptions);
                         if ($methodWrap) {
-                            if (is_object($className)) {
-                                $realClassName = get_class($className);
-                            }else {
-                                $realClassName = $className;
+                            if ($namespace) {
+                                $realClassName = $namespace;
+                            } else {
+                                if (is_object($className)) {
+                                    $realClassName = get_class($className);
+                                }else {
+                                    $realClassName = $className;
+                                }
                             }
                             $results[$prefix."$realClassName.$mName"] = $methodWrap;
                         }

--- a/tests/5ServerTest.php
+++ b/tests/5ServerTest.php
@@ -826,6 +826,15 @@ And turned it into nylon';
         $this->assertEquals('Michigan', $v->scalarval());
     }
 
+    public function testServerWrappedClassWithNamespace()
+    {
+        $m = new xmlrpcmsg('namespacetest.findState', array(
+            new xmlrpcval(23, 'int'),
+        ));
+        $v = $this->send($m);
+        $this->assertEquals('Michigan', $v->scalarval());
+    }
+
     public function testWrappedMethod()
     {
         // make a 'deep client copy' as the original one might have many properties set


### PR DESCRIPTION
Hi,
i needed the functionality to set the namespace different then the actual class namespace.
e.g
class **\Some\Namespace\API** would be mapped with this namespace, but we needed the namespace to be "My" so the XMLRPC method can be called as **My.functionName** instead of **\Some\Namespace\API.functionName**

Instead i have to write this code:
```
        $wrapper = new \PhpXmlRpc\Wrapper();
        $namespace = 'My';
        $mappings = [];
        $rc = new \ReflectionClass(get_class($myService));
        foreach ($rc->getMethods() as $method) {
            $mappings[$namespace.'.'.$method->getName()] = $wrapper->wrapPhpFunction(array($myService, $method->getName()));
        }
        new \PhpXmlRpc\Server($mappings, false);
```


Thanks in advance