### PR TITLE
HTTP/2 support

### DIFF
--- a/src/Helper/Http.php
+++ b/src/Helper/Http.php
@@ -115,13 +115,13 @@ class Http
 
         // When using Curl to query servers using Digest Auth, we get back a double set of http headers.
         // We strip out the 1st...
-        if ($headersProcessed && preg_match('/^HTTP\/[0-9]\.[0-9] 401 /', $data)) {
-            if (preg_match('/(\r?\n){2}HTTP\/[0-9]\.[0-9] 200 /', $data)) {
-                $data = preg_replace('/^HTTP\/[0-9]\.[0-9] 401 .+?(?:\r?\n){2}(HTTP\/[0-9.]+ 200 )/s', '$1', $data, 1);
+        if ($headersProcessed && preg_match('/^HTTP\/[0-9](?:\.[0-9])? 401 /', $data)) {
+            if (preg_match('/(\r?\n){2}HTTP\/[0-9](?:\.[0-9])? 200 /', $data)) {
+                $data = preg_replace('/^HTTP\/[0-9](?:\.[0-9])? 401 .+?(?:\r?\n){2}(HTTP\/[0-9.]+ 200 )/s', '$1', $data, 1);
             }
         }
 
-        if (preg_match('/^HTTP\/[0-9]\.[0-9] ([0-9]{3}) /', $data, $matches)) {
+        if (preg_match('/^HTTP\/[0-9](?:\.[0-9])? ([0-9]{3}) /', $data, $matches)) {
             $httpResponse['status_code'] = $matches[1];
         }
 


### PR DESCRIPTION
Here is a sample HTTP/2 response head:

```http
HTTP/2 200 
server: ddos-guard
date: Mon, 31 Jan 2022 09:33:45 GMT
content-type: text/xml
content-encoding: gzip
vary: Accept-Encoding
```

Not that it is not `HTTP/2.0`, but just `HTTP/2`!