### PR TITLE
Fixed utf8_encode and utf8_decode functions deprecated in PHP 8.2

### DIFF
--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -307,11 +307,7 @@ class Encoder
                 if (function_exists('mb_convert_encoding')) {
                     $xmlVal = mb_convert_encoding($xmlVal, 'UTF-8', $valEncoding);
                 } else {
-                    if ($valEncoding == 'ISO-8859-1') {
-                        $xmlVal = utf8_encode($xmlVal);
-                    } else {
-                        $this->getLogger()->error('XML-RPC: ' . __METHOD__ . ': invalid charset encoding of xml text: ' . $valEncoding);
-                    }
+                    $this->getLogger()->error('XML-RPC: ' . __METHOD__ . ': invalid charset encoding of xml text: ' . $valEncoding);
                 }
             }
         }

--- a/src/Helper/Charset.php
+++ b/src/Helper/Charset.php
@@ -253,7 +253,9 @@ class Charset
             case 'ISO-8859-1_UTF-8':
                 $escapedData = str_replace(array('&', '"', "'", '<', '>'), array('&amp;', '&quot;', '&apos;', '&lt;', '&gt;'), $data);
                 /// @todo if on php >= 8.2, prefer using mbstring or iconv. Also: suppress the warning!
-                $escapedData = utf8_encode($escapedData);
+                if (function_exists('mb_convert_encoding')) {
+                    $escapedData = mb_convert_encoding($escapedData, 'UTF-8', 'ISO-8859-1');
+                }
                 break;
 
             case 'ISO-8859-1_US-ASCII':
@@ -274,7 +276,7 @@ class Charset
                 $escapedData = str_replace(array('&', '"', "'", '<', '>'), array('&amp;', '&quot;', '&apos;', '&lt;', '&gt;'), $data);
                 /// @todo we could use real UTF8 chars here instead of xml entities... (note that utf_8 encode all alone will NOT convert them)
                 $escapedData = str_replace($this->xml_cp1252_Entities['in'], $this->xml_cp1252_Entities['out'], $escapedData);
-                $escapedData = utf8_encode($escapedData);
+                $escapedData = mb_convert_encoding($escapedData, 'UTF-8', 'ISO-8859-1');
                 break;
             case 'CP1252_ISO-8859-1':
                 $this->buildConversionTable('xml_cp1252_Entities');

--- a/src/Request.php
+++ b/src/Request.php
@@ -291,11 +291,7 @@ class Request
                 if (function_exists('mb_convert_encoding')) {
                     $data = mb_convert_encoding($data, 'UTF-8', $respEncoding);
                 } else {
-                    if ($respEncoding == 'ISO-8859-1') {
-                        $data = utf8_encode($data);
-                    } else {
-                        $this->getLogger()->error('XML-RPC: ' . __METHOD__ . ': unsupported charset encoding of received response: ' . $respEncoding);
-                    }
+                    $this->getLogger()->error('XML-RPC: ' . __METHOD__ . ': unsupported charset encoding of received response: ' . $respEncoding);
                 }
             }
         }

--- a/src/Server.php
+++ b/src/Server.php
@@ -553,11 +553,7 @@ class Server
                 if (function_exists('mb_convert_encoding')) {
                     $data = mb_convert_encoding($data, 'UTF-8', $reqEncoding);
                 } else {
-                    if ($reqEncoding == 'ISO-8859-1') {
-                        $data = utf8_encode($data);
-                    } else {
-                        $this->getLogger()->error('XML-RPC: ' . __METHOD__ . ': unsupported charset encoding of received request: ' . $reqEncoding);
-                    }
+                    $this->getLogger()->error('XML-RPC: ' . __METHOD__ . ': unsupported charset encoding of received request: ' . $reqEncoding);
                 }
             }
         }


### PR DESCRIPTION
Request PR for files. 
According to the PHP documentation utf8_encode and utf8_decode functions are deprecated in version 8.2
https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated
https://www.php.net/manual/en/function.utf8-encode.php