### PR TITLE
Fixed PHP 8.2 utf8_encode deprecated in Charset.php

### DIFF
--- a/src/Helper/Charset.php
+++ b/src/Helper/Charset.php
@@ -253,7 +253,11 @@ class Charset
             case 'ISO-8859-1_UTF-8':
                 $escapedData = str_replace(array('&', '"', "'", '<', '>'), array('&amp;', '&quot;', '&apos;', '&lt;', '&gt;'), $data);
                 /// @todo if on php >= 8.2, prefer using mbstring or iconv. Also: suppress the warning!
-                $escapedData = utf8_encode($escapedData);
+                if (function_exists('mb_convert_encoding')) {
+                        $escapedData = mb_convert_encoding($escapedData, 'UTF-8', 'ISO-8859-1');
+                } else {
+                    $escapedData = utf8_encode($escapedData);
+                }
                 break;
 
             case 'ISO-8859-1_US-ASCII':


### PR DESCRIPTION
Hi, 
According to my last comment on this PR https://github.com/gggeek/phpxmlrpc/pull/109
I've create a new PR to include the fix of the utf8_encode in the file src/Helper/Charset.php. 
Even if this scenario is not very common it will fail when PHP 8.2 is used.
I have follow the same logic as you did for the other utf8 encoding situations in case you want to include it. 
Thank you!